### PR TITLE
bump gha versions and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily

--- a/.github/workflows/poc-zombienet.yml
+++ b/.github/workflows/poc-zombienet.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # toolchain
       - name: Install toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/solo-tps-bench.yml
+++ b/.github/workflows/solo-tps-bench.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # toolchain
       - name: Install toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
       # Steps taken from https://github.com/actions/cache/blob/master/examples.md#rust---cargo
     - name: Cache cargo registry
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cargo/registry


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.
Additionally added `dependabot` to track GHA version changes.
Related issues and policy:
https://github.com/paritytech/ci_cd/issues/114
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies