### PR TITLE
tps prometheus

### DIFF
--- a/utils/tps/Cargo.toml
+++ b/utils/tps/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 utils = { path = ".."}
+anyhow = "1.0.71"
 log = "0.4.16"
 env_logger = "0.9.0"
 clap = { version = "4.0.32", features = ["derive"] }
@@ -15,6 +16,8 @@ polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch =
 futures-util = "0.3.28"
 parity-scale-codec = { version = "3.5.0", features = ["derive"] }
 subxt = "0.28.0"
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "master" }
+
 
 [[bin]]
 name = "tps"

--- a/utils/tps/src/main.rs
+++ b/utils/tps/src/main.rs
@@ -166,7 +166,7 @@ async fn calc_para_tps(
 
 		// send metrics to prometheus, if enabled
 		if let Some(metrics) = &prometheus_metrics {
-			metrics.set(trx_in_parablock, parablock_time);
+			metrics.set(trx_in_parablock, parablock_time, parablock_number);
 		}
 	}
 	trx_in_parablock = 0;
@@ -249,7 +249,7 @@ pub async fn calc_relay_tps(api: &Api, n: usize, genesis: bool, prometheus_metri
 
 		// send metrics to prometheus, if enabled
 		if let Some(metrics) = &prometheus_metrics {
-			metrics.set(tps_count, time_diff);
+			metrics.set(tps_count, time_diff, block_number_x);
 		}
 
 		block_number_x += 1;

--- a/utils/tps/src/prometheus.rs
+++ b/utils/tps/src/prometheus.rs
@@ -1,0 +1,56 @@
+use prometheus_endpoint::{prometheus::{Gauge, IntGauge, Opts}, Registry};
+use std::net::ToSocketAddrs;
+
+pub struct StpsMetrics {
+    block_tps: Gauge,
+    block_tx_count: IntGauge,
+    block_time: IntGauge,
+}
+
+impl StpsMetrics {
+    pub fn set(&self, tx_count: u64, block_time: u64) {
+        self.block_tps.set((tx_count / block_time) as f64);
+        self.block_tx_count.set(tx_count as i64);
+        self.block_time.set(block_time as i64);
+    }
+}
+
+pub async fn run_prometheus_endpoint(prometheus_url: &String, prometheus_port: &u16) -> anyhow::Result<StpsMetrics> {
+    let registry = Registry::new_custom(Some("sTPS".into()), None)?;
+    let metrics = register_metrics(&registry)?;
+    let socket_addr_str = format!("{}:{}", prometheus_url, prometheus_port);
+    for addr in socket_addr_str.to_socket_addrs()? {
+        let prometheus_registry = registry.clone();
+        tokio::spawn(prometheus_endpoint::init_prometheus(addr, prometheus_registry));
+    }
+
+    Ok(metrics)
+}
+
+fn register_metrics(registry: &Registry) -> anyhow::Result<StpsMetrics> {
+    Ok(StpsMetrics {
+        block_tps: prometheus_endpoint::register(
+           Gauge::with_opts(
+               Opts::new(
+                   "tps",
+                   "Transactions per second in the block",
+               )
+           )?,
+           &registry
+        )?,
+        block_tx_count: prometheus_endpoint::register(
+           IntGauge::new(
+               "tx_count",
+               "Number of transactions in the block",
+           )?,
+           &registry
+        )?,
+        block_time: prometheus_endpoint::register(
+           IntGauge::new(
+               "block_time",
+               "Block time delta in milliseconds",
+           )?,
+           &registry
+        )?,
+    })
+}


### PR DESCRIPTION
The work done so far was mostly following [`polkadot-introspector`](https://github.com/paritytech/polkadot-introspector/blob/master/parachain-tracer/src/prometheus.rs) as a reference for writing the minimum necessary boilerplate for Prometheus integration into the `tps` crate.

Some ToDos:
- Hasn't been tested against a real Prometheus instance. So far I only got this to compile.
- I wonder if we could use some [Histogram](https://docs.rs/prometheus/latest/prometheus/struct.Histogram.html) to observe the successive `block_tx_count` and `block_time` across time.