### PR TITLE
Fix stuck event counter loop, and accurately represent time-diff

### DIFF
--- a/utils/tps/src/main.rs
+++ b/utils/tps/src/main.rs
@@ -134,10 +134,10 @@ async fn calc_para_tps(
 					.fetch(&storage_timestamp_storage_addr, Some(previous_hash))
 					.await?
 					.unwrap();
-				let time_diff = parablock_timestamp - previous_parablock_timestamp;
+				let time_diff = (parablock_timestamp - previous_parablock_timestamp)/1000;
 				info!("TPS Counter ===> Parablock time estimated at: {:?}", time_diff);
 				time_diff
-			}
+			},
 			// Assume default if unable to get the previous parablock from parablock number
 			None => {
 				warn!(
@@ -148,13 +148,12 @@ async fn calc_para_tps(
 			},
 		};
 		for extrinsic in parabody.extrinsics() {
-			while let Ok(events) = extrinsic.events().await {
-				for event in events.iter() {
-					let evt = event?;
-					let variant = evt.variant_name();
-					if variant == "Transfer" {
-						trx_in_parablock += 1;
-					}
+			let events = extrinsic.events().await?;
+			for event in events.iter() {
+				let evt = event?;
+				let variant = evt.variant_name();
+				if variant == "Transfer" {
+					trx_in_parablock += 1;
 				}
 			}
 		}

--- a/utils/tps/src/prometheus.rs
+++ b/utils/tps/src/prometheus.rs
@@ -1,63 +1,66 @@
-use prometheus_endpoint::{prometheus::{GaugeVec, IntGaugeVec, Opts}, Registry};
+use prometheus_endpoint::{
+	prometheus::{GaugeVec, IntGaugeVec, Opts},
+	Registry,
+};
 use std::net::ToSocketAddrs;
 
 pub struct StpsMetrics {
-    block_tps: GaugeVec,
-    block_tx_count: IntGaugeVec,
-    block_time: IntGaugeVec,
+	block_tps: GaugeVec,
+	block_tx_count: IntGaugeVec,
+	block_time: IntGaugeVec,
 }
 
 impl StpsMetrics {
-    pub fn set(&self, tx_count: u64, block_time: u64, block_number: u32) {
-        self.block_tps.with_label_values(&[&block_number.to_string()]).set(tx_count as f64 / block_time as f64);
-        self.block_time.with_label_values(&[&block_number.to_string()]).set(block_time as i64);
-        self.block_tx_count.with_label_values(&[&block_number.to_string()]).set(tx_count as i64);
-    }
+	pub fn set(&self, tx_count: u64, block_time: u64, block_number: u32) {
+		self.block_tps
+			.with_label_values(&[&block_number.to_string()])
+			.set(tx_count as f64 / block_time as f64);
+		self.block_time
+			.with_label_values(&[&block_number.to_string()])
+			.set(block_time as i64);
+		self.block_tx_count
+			.with_label_values(&[&block_number.to_string()])
+			.set(tx_count as i64);
+	}
 }
 
-pub async fn run_prometheus_endpoint(prometheus_url: &String, prometheus_port: &u16) -> anyhow::Result<StpsMetrics> {
-    let registry = Registry::new_custom(Some("sTPS".into()), None)?;
-    let metrics = register_metrics(&registry)?;
-    let socket_addr_str = format!("{}:{}", prometheus_url, prometheus_port);
-    for addr in socket_addr_str.to_socket_addrs()? {
-        let prometheus_registry = registry.clone();
-        tokio::spawn(prometheus_endpoint::init_prometheus(addr, prometheus_registry));
-    }
+pub async fn run_prometheus_endpoint(
+	prometheus_url: &String,
+	prometheus_port: &u16,
+) -> anyhow::Result<StpsMetrics> {
+	let registry = Registry::new_custom(Some("sTPS".into()), None)?;
+	let metrics = register_metrics(&registry)?;
+	let socket_addr_str = format!("{}:{}", prometheus_url, prometheus_port);
+	for addr in socket_addr_str.to_socket_addrs()? {
+		let prometheus_registry = registry.clone();
+		tokio::spawn(prometheus_endpoint::init_prometheus(addr, prometheus_registry));
+	}
 
-    Ok(metrics)
+	Ok(metrics)
 }
 
 fn register_metrics(registry: &Registry) -> anyhow::Result<StpsMetrics> {
-    Ok(StpsMetrics {
-        block_tps: prometheus_endpoint::register(
-           GaugeVec::new(
-               Opts::new(
-                   "tps",
-                   "Transactions per second in the block",
-               ),
-               &["block_number"],
-           )?,
-           &registry
-        )?,
-        block_tx_count: prometheus_endpoint::register(
-           IntGaugeVec::new(
-               Opts::new(
-                   "tx_count",
-                   "Number of transactions in the block",
-               ),
-               &["block_number"],
-           )?,
-           &registry
-        )?,
-        block_time: prometheus_endpoint::register(
-           IntGaugeVec::new(
-               Opts::new(
-                   "block_time",
-                   "Block time delta in milliseconds",
-               ),
-               &["block_number"],
-           )?,
-           &registry
-        )?,
-    })
+	Ok(StpsMetrics {
+		block_tps: prometheus_endpoint::register(
+			GaugeVec::new(
+				Opts::new("tps", "Transactions per second in the block"),
+				&["block_number"],
+			)?,
+			&registry,
+		)?,
+		block_tx_count: prometheus_endpoint::register(
+			IntGaugeVec::new(
+				Opts::new("tx_count", "Number of transactions in the block"),
+				&["block_number"],
+			)?,
+			&registry,
+		)?,
+		block_time: prometheus_endpoint::register(
+			IntGaugeVec::new(
+				Opts::new("block_time", "Block time delta in milliseconds"),
+				&["block_number"],
+			)?,
+			&registry,
+		)?,
+	})
 }


### PR DESCRIPTION
The `while let Ok(events) = extrinsic.events().await` block in the `calc_para_tps` method blocks, hence this was fixed with a simple `let events = extrinsic.events().await?;` call.

Additionally, the `time_diff` parameter was scaled to be represented in seconds rather than milliseconds. 