### PR TITLE
Add skip for parablock number 1 to avoid panic on time difference calculation

### DIFF
--- a/utils/tps/src/main.rs
+++ b/utils/tps/src/main.rs
@@ -114,7 +114,7 @@ async fn calc_para_tps(
 		let parablock_hash = parablock.hash();
 		let parablock_number = parablock.number();
 		
-		// Skip the first parablock as no way to calculate time-difference between it and non-existging block
+		// Skip the first parablock as no way to calculate time-difference between it and non-existing block 0
 		if parablock_number == 1 {
 			info!("TPS Counter ===> Received Parablock number: {:?}, skipping accordingly.", parablock_number);
 			continue;

--- a/utils/tps/src/main.rs
+++ b/utils/tps/src/main.rs
@@ -113,6 +113,13 @@ async fn calc_para_tps(
 		let parabody = parablock.body().await?;
 		let parablock_hash = parablock.hash();
 		let parablock_number = parablock.number();
+		
+		// Skip the first parablock as no way to calculate time-difference between it and non-existging block
+		if parablock_number == 1 {
+			info!("TPS Counter ===> Received Parablock number: {:?}, skipping accordingly.", parablock_number);
+			continue;
+		}
+
 		let previous_parablock_number = parablock_number - 1;
 		let maybe_previous_parablock_hash =
 			para_api.rpc().block_hash(Some(previous_parablock_number.into())).await?;


### PR DESCRIPTION
Closes #51 

This is a simple fix. We can think of alternative ways going forwards.