### PR TITLE
refactor(funder): remove subxt dep and allow to specify ss58 format

### DIFF
--- a/utils/funder/Cargo.toml
+++ b/utils/funder/Cargo.toml
@@ -8,15 +8,10 @@ edition = "2021"
 [dependencies]
 utils = { path = ".." }
 log = "0.4.16"
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 futures = "0.3.21"
 serde_json = "1.0.81"
 sp-core = { version = "7.0.0", default-features = false  }
 sp-runtime = "7.0.0"
-subxt = "0.25.0"
 tokio = { version = "1.18.0", features = ["rt-multi-thread", "macros", "time"] }
 clap = { version = "4.0.32", features = ["derive"] }
-
-[features]
-tick = ["utils/tick"]
-rococo = ["utils/rococo"]


### PR DESCRIPTION
Hi @bredamatt / @bernardoaraujor,  this refactor allow to specify the ss58 format ( fixes #33 ) and remove the usage of `subxt` to create the accounts. 
Thanks!
                                                               