### PR TITLE
Use last finalised head rather than genesis in sender pre-conditions

### DIFF
--- a/utils/sender/src/main.rs
+++ b/utils/sender/src/main.rs
@@ -36,10 +36,6 @@ struct Args {
 	/// Total number of pre-funded accounts (on funded-accounts.json).
 	#[arg(long)]
 	num: usize,
-
-	/// Whether to trigger transfers on a parachain, or relaychain.
-	#[arg(long, default_value_t = false)]
-	para_finality: bool,
 }
 
 async fn send_funds(
@@ -136,11 +132,10 @@ async fn main() -> Result<(), Error> {
 	);
 
 	let args = Args::parse();
-	let para_finality = args.para_finality;
 	let api = connect(&args.node_url).await?;
 	let n_tx_sender = args.num / args.total_senders;
 
-	pre_conditions(&api, args.sender_index, n_tx_sender, para_finality).await?;
+	pre_conditions(&api, args.sender_index, n_tx_sender).await?;
 
 	send_funds(&api, args.sender_index, args.chunk_size, n_tx_sender).await?;
 

--- a/utils/sender/src/main.rs
+++ b/utils/sender/src/main.rs
@@ -36,6 +36,10 @@ struct Args {
 	/// Total number of pre-funded accounts (on funded-accounts.json).
 	#[arg(long)]
 	num: usize,
+
+	/// Whether to trigger transfers on a parachain, or relaychain.
+	#[arg(long, default_value_t = false)]
+	para_finality: bool,
 }
 
 async fn send_funds(
@@ -132,11 +136,11 @@ async fn main() -> Result<(), Error> {
 	);
 
 	let args = Args::parse();
-
+	let para_finality = args.para_finality;
 	let api = connect(&args.node_url).await?;
 	let n_tx_sender = args.num / args.total_senders;
 
-	pre_conditions(&api, args.sender_index, n_tx_sender).await?;
+	pre_conditions(&api, args.sender_index, n_tx_sender, para_finality).await?;
 
 	send_funds(&api, args.sender_index, args.chunk_size, n_tx_sender).await?;
 

--- a/utils/sender/src/pre/mod.rs
+++ b/utils/sender/src/pre/mod.rs
@@ -6,7 +6,7 @@ use subxt::{tx::PairSigner, PolkadotConfig};
 use utils::{runtime, Api, Error, DERIVATION};
 
 /// Check pre-conditions of accounts attributed to this sender
-pub async fn pre_conditions(api: &Api, i: usize, n: usize, para_finality: bool) -> Result<(), Error> {
+pub async fn pre_conditions(api: &Api, i: usize, n: usize) -> Result<(), Error> {
 	info!(
 		"Sender {}: checking pre-conditions of accounts {}{} through {}{}",
 		i,
@@ -22,38 +22,30 @@ pub async fn pre_conditions(api: &Api, i: usize, n: usize, para_finality: bool) 
 		let signer: PairSigner<PolkadotConfig, SrPair> = PairSigner::new(pair);
 		let account = signer.account_id();
 		info!("Checking account: {}", account);
-		check_account(&api, account, para_finality).await?;
+		check_account(&api, account).await?;
 	}
 
 	Ok(())
 }
 
 /// Check account nonce and free balance
-async fn check_account(api: &Api, account: &AccountId32, para_finality: bool) -> Result<(), Error> {
+async fn check_account(api: &Api, account: &AccountId32) -> Result<(), Error> {
 	let ext_deposit_addr = runtime::constants().balances().existential_deposit();
 	let ext_deposit = api.constants().at(&ext_deposit_addr)?;
 	let account_state_storage_addr = runtime::storage().system().account(account);	
-	
-	match para_finality {
-		true => {
-			// TODO: Need to check accounts in parablock
-		},
-		false => {
-			let finalized_head_hash = api.rpc().finalized_head().await?;
-			let account_state =
-				api.storage().fetch(&account_state_storage_addr, Some(finalized_head_hash)).await?.unwrap();
+	let finalized_head_hash = api.rpc().finalized_head().await?;
+	let account_state =
+		api.storage().fetch(&account_state_storage_addr, Some(finalized_head_hash)).await?.unwrap();
 
-			if account_state.nonce != 0 {
-				panic!("Account has non-zero nonce");
-			}
+	if account_state.nonce != 0 {
+		panic!("Account has non-zero nonce");
+	}
 
-			if (account_state.data.free as f32) < ext_deposit as f32 * 1.1
-			/* 10% for fees */
-			{
-				// 10% for fees
-				panic!("Account has insufficient funds");
-			}
-		}
+	if (account_state.data.free as f32) < ext_deposit as f32 * 1.1
+	/* 10% for fees */
+	{
+		// 10% for fees
+		panic!("Account has insufficient funds");
 	}
 	Ok(())
 }

--- a/utils/sender/src/pre/mod.rs
+++ b/utils/sender/src/pre/mod.rs
@@ -6,7 +6,7 @@ use subxt::{tx::PairSigner, PolkadotConfig};
 use utils::{runtime, Api, Error, DERIVATION};
 
 /// Check pre-conditions of accounts attributed to this sender
-pub async fn pre_conditions(api: &Api, i: usize, n: usize) -> Result<(), Error> {
+pub async fn pre_conditions(api: &Api, i: usize, n: usize, para_finality: bool) -> Result<(), Error> {
 	info!(
 		"Sender {}: checking pre-conditions of accounts {}{} through {}{}",
 		i,
@@ -22,35 +22,38 @@ pub async fn pre_conditions(api: &Api, i: usize, n: usize) -> Result<(), Error> 
 		let signer: PairSigner<PolkadotConfig, SrPair> = PairSigner::new(pair);
 		let account = signer.account_id();
 		info!("Checking account: {}", account);
-		check_account(&api, account).await?;
+		check_account(&api, account, para_finality).await?;
 	}
 
 	Ok(())
 }
 
 /// Check account nonce and free balance
-async fn check_account(api: &Api, account: &AccountId32) -> Result<(), Error> {
+async fn check_account(api: &Api, account: &AccountId32, para_finality: bool) -> Result<(), Error> {
 	let ext_deposit_addr = runtime::constants().balances().existential_deposit();
 	let ext_deposit = api.constants().at(&ext_deposit_addr)?;
+	let account_state_storage_addr = runtime::storage().system().account(account);	
+	
+	match para_finality {
+		true => {
+			// TODO: Need to check accounts in parablock
+		},
+		false => {
+			let finalized_head_hash = api.rpc().finalized_head().await?;
+			let account_state =
+				api.storage().fetch(&account_state_storage_addr, Some(finalized_head_hash)).await?.unwrap();
 
-	let genesis = 0u32;
-	let genesis_hash = api.rpc().block_hash(Some(genesis.into())).await?;
+			if account_state.nonce != 0 {
+				panic!("Account has non-zero nonce");
+			}
 
-	// let account_state = runtime::storage().system().account(account, genesis_hash).await?;
-	let account_state_storage_addr = runtime::storage().system().account(account);
-	let account_state =
-		api.storage().fetch(&account_state_storage_addr, genesis_hash).await?.unwrap();
-
-	if account_state.nonce != 0 {
-		panic!("Account has non-zero nonce");
+			if (account_state.data.free as f32) < ext_deposit as f32 * 1.1
+			/* 10% for fees */
+			{
+				// 10% for fees
+				panic!("Account has insufficient funds");
+			}
+		}
 	}
-
-	if (account_state.data.free as f32) < ext_deposit as f32 * 1.1
-	/* 10% for fees */
-	{
-		// 10% for fees
-		panic!("Account has insufficient funds");
-	}
-
 	Ok(())
 }


### PR DESCRIPTION
Closes #58 

Here it is assumed that both parachain and relaychain `Balances` accounts can be checked the same way. The first commit assumes otherwise, so do feel free to compare and LMK your thoughts.