### PR TITLE
Add average parachain tps calculation

### DIFF
--- a/tests/kubernetes/para-single.json
+++ b/tests/kubernetes/para-single.json
@@ -35,6 +35,15 @@
     {
       "id": 1000,
       "cumulus_based": true,
+      "genesis": {
+        "runtime": {
+          "runtime_genesis_config": {
+            "balances": {
+              "balances": {% include "../funded-accounts.json" %}
+            }
+          }
+        }
+      },
       "collator": {
         "name": "collator01",
         "ws_port": "9944",

--- a/tests/native/multi-para-native.json
+++ b/tests/native/multi-para-native.json
@@ -24,6 +24,15 @@
       {
         "id": 1000,
         "cumulus_based": true,
+        "genesis": {
+          "runtime": {
+            "runtime_genesis_config": {
+              "balances": {
+                "balances": {% include "../funded-accounts.json" %}
+              }
+            }
+          }
+        },
         "collator": {
           "name": "collator1000",
           "ws_port": "9999",
@@ -36,6 +45,15 @@
       {
         "id": 1001,
         "cumulus_based": true,
+        "genesis": {
+          "runtime": {
+            "runtime_genesis_config": {
+              "balances": {
+                "balances": {% include "../funded-accounts.json" %}
+              }
+            }
+          }
+        },
         "collator": {
           "name": "collator1001",
           "ws_port": "9998",

--- a/tests/native/multi-para-native.json
+++ b/tests/native/multi-para-native.json
@@ -26,10 +26,8 @@
         "cumulus_based": true,
         "genesis": {
           "runtime": {
-            "runtime_genesis_config": {
-              "balances": {
-                "balances": {% include "../funded-accounts.json" %}
-              }
+            "balances": {
+              "balances": {% include "../funded-accounts.json" %}
             }
           }
         },
@@ -47,10 +45,8 @@
         "cumulus_based": true,
         "genesis": {
           "runtime": {
-            "runtime_genesis_config": {
-              "balances": {
-                "balances": {% include "../funded-accounts.json" %}
-              }
+            "balances": {
+              "balances": {% include "../funded-accounts.json" %}
             }
           }
         },

--- a/tests/native/single-para-native.json
+++ b/tests/native/single-para-native.json
@@ -24,6 +24,15 @@
     {
       "id": 1000,
       "cumulus_based": true,
+      "genesis": {
+        "runtime": {
+          "runtime_genesis_config": {
+            "balances": {
+              "balances": {% include "../funded-accounts.json" %}
+            }
+          }
+        }
+      },
       "collator": {
         "name": "collator01",
         "ws_port": "9999",

--- a/tests/native/single-para-native.json
+++ b/tests/native/single-para-native.json
@@ -26,10 +26,8 @@
       "cumulus_based": true,
       "genesis": {
         "runtime": {
-          "runtime_genesis_config": {
-            "balances": {
-              "balances": {% include "../funded-accounts.json" %}
-            }
+          "balances": {
+            "balances": {% include "../funded-accounts.json" %}
           }
         }
       },

--- a/utils/dockerfiles/Dockerfile.funder
+++ b/utils/dockerfiles/Dockerfile.funder
@@ -1,4 +1,4 @@
-FROM rust:latest as builder
+FROM paritytech/ci-linux:production as builder
 
 COPY . /build
 

--- a/utils/dockerfiles/Dockerfile.sender
+++ b/utils/dockerfiles/Dockerfile.sender
@@ -1,4 +1,4 @@
-FROM rust:latest as builder
+FROM paritytech/ci-linux:production as builder
 
 COPY . /build
 

--- a/utils/dockerfiles/Dockerfile.tps
+++ b/utils/dockerfiles/Dockerfile.tps
@@ -1,4 +1,4 @@
-FROM rust:latest as builder
+FROM paritytech/ci-linux:production as builder
 
 COPY . /build
 

--- a/utils/sender/src/pre/mod.rs
+++ b/utils/sender/src/pre/mod.rs
@@ -32,10 +32,13 @@ pub async fn pre_conditions(api: &Api, i: usize, n: usize) -> Result<(), Error> 
 async fn check_account(api: &Api, account: &AccountId32) -> Result<(), Error> {
 	let ext_deposit_addr = runtime::constants().balances().existential_deposit();
 	let ext_deposit = api.constants().at(&ext_deposit_addr)?;
-	let account_state_storage_addr = runtime::storage().system().account(account);	
+	let account_state_storage_addr = runtime::storage().system().account(account);
 	let finalized_head_hash = api.rpc().finalized_head().await?;
-	let account_state =
-		api.storage().fetch(&account_state_storage_addr, Some(finalized_head_hash)).await?.unwrap();
+	let account_state = api
+		.storage()
+		.fetch(&account_state_storage_addr, Some(finalized_head_hash))
+		.await?
+		.unwrap();
 
 	if account_state.nonce != 0 {
 		panic!("Account has non-zero nonce");

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -37,7 +37,10 @@ pub async fn connect(url: &str) -> Result<Api, Error> {
 		let promise = OnlineClient::<PolkadotConfig>::from_url(url);
 
 		match promise.await {
-			Ok(client) => return Ok(client),
+			Ok(client) => {
+				info!("Connection established to: {}", url);
+				return Ok(client)
+			},
 			Err(err) => {
 				warn!("API client {} error: {:?}", url, err);
 				tokio::time::sleep(RETRY_DELAY).await;


### PR DESCRIPTION
Added some similar logic to the relay tps calculation where tps estimates are added to a vec and calculated as an average afterwards as it was missing. 

Also added now working zombienet network configurations that support chainspec overrides with funded-accounts.