### PR TITLE
Return official rust image as docker builder

### DIFF
--- a/docker/parachain-collator_builder.Dockerfile
+++ b/docker/parachain-collator_builder.Dockerfile
@@ -1,6 +1,6 @@
 # This file is sourced from https://github.com/paritytech/polkadot/blob/master/scripts/ci/dockerfiles/polkadot/polkadot_builder.Dockerfile
 # This is the build stage for Polkadot. Here we create the binary in a temporary image.
-FROM docker.io/paritytech/ci-linux:production as builder
+FROM rust:latest as builder
 
 WORKDIR /polkadot
 COPY . /polkadot

--- a/utils/dockerfiles/Dockerfile.funder
+++ b/utils/dockerfiles/Dockerfile.funder
@@ -1,4 +1,4 @@
-FROM paritytech/ci-linux:production as builder
+FROM rust:latest as builder
 
 COPY . /build
 

--- a/utils/dockerfiles/Dockerfile.sender
+++ b/utils/dockerfiles/Dockerfile.sender
@@ -1,4 +1,4 @@
-FROM paritytech/ci-linux:production as builder
+FROM rust:latest as builder
 
 COPY . /build
 

--- a/utils/dockerfiles/Dockerfile.tps
+++ b/utils/dockerfiles/Dockerfile.tps
@@ -1,4 +1,4 @@
-FROM paritytech/ci-linux:production as builder
+FROM rust:latest as builder
 
 COPY . /build
 


### PR DESCRIPTION
Use [official Rust Docker Image](https://hub.docker.com/_/rust) instead of [paritytech/ci-linux](https://hub.docker.com/r/paritytech/ci-linux/) as additional functionality provided by the latter is not needed, and official Rust is much lighter.